### PR TITLE
use BIP32 HMAC key specified in BIP0032

### DIFF
--- a/BreadWallet/BRBIP32Sequence.m
+++ b/BreadWallet/BRBIP32Sequence.m
@@ -31,7 +31,7 @@
 #import <CommonCrypto/CommonHMAC.h>
 
 #define BIP32_HARD     0x80000000u //not sure about this one
-#define BIP32_SEED_KEY "Darkcoin seed"
+#define BIP32_SEED_KEY "Bitcoin seed"
 #define BIP32_XPRV     "\x02\xFE\x52\xCC" //// Dash BIP32 prvkeys start with 'drkp'
 #define BIP32_XPUB     "\x02\xFE\x52\xF8" //// Dash BIP32 pubkeys start with 'drkv'
 


### PR DESCRIPTION
This fixes the issue where a seed phrase generated with this app can't be used with any other wallet software. To be fair, I don't know how this will affect current iPhone Dashwallets where master keys have been generated already. (But since it's not yet on the app store, this is likely a small number.)

But for this to correctly be called a BIP32 wallet, and for interoperability reasons, this would have to change back to using the HMAC key specified in the [BIP0032 spec](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki#master-key-generation).